### PR TITLE
Support the same .NET versions as OpenFeature

### DIFF
--- a/ProviderTests/CustomLogger.cs
+++ b/ProviderTests/CustomLogger.cs
@@ -1,4 +1,5 @@
 ﻿using Splitio.Services.Logger;
+using System;
 
 namespace ProviderTests
 {

--- a/ProviderTests/ProviderTests.cs
+++ b/ProviderTests/ProviderTests.cs
@@ -1,262 +1,266 @@
-﻿using OpenFeature;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenFeature;
 using OpenFeature.Constant;
 using OpenFeature.Model;
-using Splitio.Services.Client.Classes;
 using Splitio.OpenFeature;
+using Splitio.Services.Client.Classes;
+using System;
+using System.Threading.Tasks;
 
-namespace ProviderTests;
-
-[TestClass]
-public class ProviderTests
+namespace ProviderTests
 {
-    readonly FeatureClient client;
-
-    public ProviderTests()
+    [TestClass]
+    public class ProviderTests
     {
-        // Create the Split client
-        var config = new ConfigurationOptions
+        readonly FeatureClient client;
+
+        public ProviderTests()
         {
-            LocalhostFilePath = "../../../split.yaml",
-            Logger = new CustomLogger()
-        };
-        var factory = new SplitFactory("localhost", config);
-        var sdk = factory.Client();
-        try
-        {
-            sdk.BlockUntilReady(10000);
+            // Create the Split client
+            var config = new ConfigurationOptions
+            {
+                LocalhostFilePath = "../../../split.yaml",
+                Logger = new CustomLogger()
+            };
+            var factory = new SplitFactory("localhost", config);
+            var sdk = factory.Client();
+            try
+            {
+                sdk.BlockUntilReady(10000);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception initializing Split client! {ex}");
+                throw;
+            }
+
+            // Sets the provider used by the client
+            OpenFeature.Api.Instance.SetProviderAsync(new Provider(sdk));
+
+            // Gets a instance of the feature flag client
+            client = OpenFeature.Api.Instance.GetClient();
+            var context = EvaluationContext.Builder().Set("targetingKey", "key").Build();
+            client.SetContext(context);
         }
-        catch (Exception ex)
+
+        [TestMethod]
+        public async Task UseDefaultTest()
         {
-            Console.WriteLine($"Exception initializing Split client! {ex}");
-            throw;
+            string flagName = "random-non-existent-feature";
+
+            var result = await client.GetBooleanValueAsync(flagName, false);
+            Assert.IsFalse(result);
+            result = await client.GetBooleanValueAsync(flagName, true);
+            Assert.IsTrue(result);
+
+            string defaultString = "blah";
+            var resultString = await client.GetStringValueAsync(flagName, defaultString);
+            Assert.AreEqual(defaultString, resultString);
+
+            int defaultInt = 100;
+            var resultInt = await client.GetIntegerValueAsync(flagName, defaultInt);
+            Assert.AreEqual(defaultInt, resultInt);
+
+            Structure defaultStructure = Structure.Builder().Set("foo", new Value("bar")).Build();
+            Value resultStructure = await client.GetObjectValueAsync(flagName, new Value(defaultStructure));
+            Assert.IsTrue(StructuresMatch(defaultStructure, resultStructure.AsStructure));
         }
 
-        // Sets the provider used by the client
-        OpenFeature.Api.Instance.SetProviderAsync(new Provider(sdk));
-
-        // Gets a instance of the feature flag client
-        client = OpenFeature.Api.Instance.GetClient();
-        var context = EvaluationContext.Builder().Set("targetingKey", "key").Build();
-        client.SetContext(context);
-    }
-
-    [TestMethod]
-    public async Task UseDefaultTest()
-    {
-        String flagName = "random-non-existent-feature";
-
-        var result = await client.GetBooleanValueAsync(flagName, false);
-        Assert.IsFalse(result);
-        result = await client.GetBooleanValueAsync(flagName, true);
-        Assert.IsTrue(result);
-
-        String defaultString = "blah";
-        var resultString = await client.GetStringValueAsync(flagName, defaultString);
-        Assert.AreEqual(defaultString, resultString);
-
-        int defaultInt = 100;
-        var resultInt = await client.GetIntegerValueAsync(flagName, defaultInt);
-        Assert.AreEqual(defaultInt, resultInt);
-
-        Structure defaultStructure = Structure.Builder().Set("foo", new Value("bar")).Build();
-        Value resultStructure = await client.GetObjectValueAsync(flagName, new Value(defaultStructure));
-        Assert.IsTrue(StructuresMatch(defaultStructure, resultStructure.AsStructure));
-    }
-
-    [TestMethod]
-    public async Task MissingTargetingKeyTest()
-    {
-        client.SetContext(EvaluationContext.Builder().Build());
-        FlagEvaluationDetails<bool> details = await client.GetBooleanDetailsAsync("non-existent-feature", false);
-        Assert.IsFalse(details.Value);
-        Assert.AreEqual(ErrorType.TargetingKeyMissing, details.ErrorType);
-    }
-
-    [TestMethod]
-    public async Task GetControlVariantNonExistentSplit()
-    {
-        FlagEvaluationDetails<bool> details = await client.GetBooleanDetailsAsync("non-existent-feature", false);
-        Assert.IsFalse(details.Value);
-        Assert.AreEqual("control", details.Variant);
-        Assert.AreEqual(ErrorType.FlagNotFound, details.ErrorType);
-    }
-
-    [TestMethod]
-    public async Task GetBooleanSplitTest()
-    {
-        var result = await client.GetBooleanValueAsync("some_other_feature", true);
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public async Task GetBooleanSplitWithKeyTest()
-    {
-        var result = await client.GetBooleanValueAsync("my_feature", false);
-        Assert.IsTrue(result);
-
-        var context = EvaluationContext.Builder().Set("targetingKey", "randomKey").Build();
-        result = await client.GetBooleanValueAsync("my_feature", true, context);
-        Assert.IsFalse(result);
-    }
-
-    [TestMethod]
-    public async Task GetStringSplitTest()
-    {
-        var result = await client.GetStringValueAsync("some_other_feature", "on");
-        Assert.AreEqual("off", result);
-    }
-
-    [TestMethod]
-    public async Task GetIntegerSplitTest()
-    {
-        var result = await client.GetIntegerValueAsync("int_feature", 0);
-        Assert.AreEqual(32, result);
-    }
-
-    [TestMethod]
-    public async Task GetObjectSplitTest()
-    {
-        var result = await client.GetObjectValueAsync("obj_feature", new Value());
-        Structure expectedValue = Structure.Builder().Set("key", new Value("value")).Build();
-        Assert.IsTrue(StructuresMatch(expectedValue, result.AsStructure));
-    }
-
-    [TestMethod]
-    public async Task GetDoubleSplitTest()
-    {
-        var result = await client.GetDoubleValueAsync("int_feature", 0D);
-        Assert.AreEqual(32D, result);
-    }
-
-    [TestMethod]
-    public async Task GetBooleanDetailsTest()
-    {
-        var details = await client.GetBooleanDetailsAsync("some_other_feature", true);
-        Assert.AreEqual("some_other_feature", details.FlagKey);
-        Assert.AreEqual(Reason.TargetingMatch, details.Reason);
-        Assert.IsFalse(details.Value);
-        // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
-        Assert.AreEqual("off", details.Variant);
-        Assert.AreEqual(ErrorType.None, details.ErrorType);
-    }
-
-    [TestMethod]
-    public async Task GetIntegerDetailsAsyncTest()
-    {
-        var details = await client.GetIntegerDetailsAsync("int_feature", 0);
-        Assert.AreEqual("int_feature", details.FlagKey);
-        Assert.AreEqual(Reason.TargetingMatch, details.Reason);
-        Assert.AreEqual(32, details.Value);
-        // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
-        Assert.AreEqual("32", details.Variant);
-        Assert.AreEqual(ErrorType.None, details.ErrorType);
-    }
-
-    [TestMethod]
-    public async Task GetStringDetailsAsyncTest()
-    {
-        var details = await client.GetStringDetailsAsync("some_other_feature", "blah");
-        Assert.AreEqual("some_other_feature", details.FlagKey);
-        Assert.AreEqual(Reason.TargetingMatch, details.Reason);
-        Assert.AreEqual("off", details.Value);
-        // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
-        Assert.AreEqual("off", details.Variant);
-        Assert.AreEqual(ErrorType.None, details.ErrorType);
-    }
-
-    [TestMethod]
-    public async Task GetDoubleDetailsAsyncTest()
-    {
-        var details = await client.GetDoubleDetailsAsync("int_feature", 0D);
-        Assert.AreEqual("int_feature", details.FlagKey);
-        Assert.AreEqual(Reason.TargetingMatch, details.Reason);
-        Assert.AreEqual(32D, details.Value);
-        // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
-        Assert.AreEqual("32", details.Variant);
-        Assert.AreEqual(ErrorType.None, details.ErrorType);
-    }
-
-    [TestMethod]
-    public async Task GetObjectDetailsAsyncTest()
-    {
-        var details = await client.GetObjectDetailsAsync("obj_feature", new Value());
-        Assert.AreEqual("obj_feature", details.FlagKey);
-        Assert.AreEqual(Reason.TargetingMatch, details.Reason);
-        Structure expected = Structure.Builder().Set("key", new Value("value")).Build();
-        Assert.IsTrue(StructuresMatch(expected, details.Value.AsStructure));
-        // the flag's treatment is stored as a string, and the variant is that raw string
-        Assert.AreEqual("{\"key\": \"value\"}", details.Variant);
-        Assert.AreEqual(ErrorType.None, details.ErrorType);
-    }
-
-    [TestMethod]
-    public async Task GetBooleanFailTest()
-    {
-        // attempt to fetch an object treatment as a Boolean. Should result in the default
-        var value = await client.GetBooleanValueAsync("obj_feature", false);
-        Assert.IsFalse(value);
-
-        var details = await client.GetBooleanDetailsAsync("obj_feature", false);
-        Assert.IsFalse(details.Value);
-        Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
-        Assert.AreEqual(Reason.Error, details.Reason);
-    }
-
-    [TestMethod]
-    public async Task GetIntegerFailTest()
-    {
-        // attempt to fetch an object treatment as an integer. Should result in the default
-        var value = await client.GetIntegerValueAsync("obj_feature", 10);
-        Assert.AreEqual(10, value);
-
-        var details = await client.GetIntegerDetailsAsync("obj_feature", 10);
-        Assert.AreEqual(10, details.Value);
-        Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
-        Assert.AreEqual(Reason.Error, details.Reason);
-    }
-
-    [TestMethod]
-    public async Task GetDoubleFailTest()
-    {
-        // attempt to fetch an object treatment as a double. Should result in the default
-        var value = await client.GetDoubleValueAsync("obj_feature", 10D);
-        Assert.AreEqual(10D, value);
-
-        var details = await client.GetDoubleDetailsAsync("obj_feature", 10D);
-        Assert.AreEqual(10D, details.Value);
-        Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
-        Assert.AreEqual(Reason.Error, details.Reason);
-    }
-
-    [TestMethod]
-    public async Task GetObjectFailTest()
-    {
-        // attempt to fetch an int as an object. Should result in the default
-        Structure defaultValue = Structure.Builder().Set("key", new Value("value")).Build();
-        var value = await client.GetObjectValueAsync("int_feature", new Value(defaultValue));
-        Assert.IsTrue(StructuresMatch(defaultValue, value.AsStructure));
-
-        var details = await client.GetObjectDetailsAsync("int_feature", new Value(defaultValue));
-        Assert.IsTrue(StructuresMatch(defaultValue, details.Value.AsStructure));
-        Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
-        Assert.AreEqual(Reason.Error, details.Reason);
-    }
-
-    private static bool StructuresMatch(Structure s1, Structure s2)
-    {
-        if (s1.Count != s2.Count)
+        [TestMethod]
+        public async Task MissingTargetingKeyTest()
         {
-            return false;
+            client.SetContext(EvaluationContext.Builder().Build());
+            FlagEvaluationDetails<bool> details = await client.GetBooleanDetailsAsync("non-existent-feature", false);
+            Assert.IsFalse(details.Value);
+            Assert.AreEqual(ErrorType.TargetingKeyMissing, details.ErrorType);
         }
-        foreach (string key in s1.Keys)
+
+        [TestMethod]
+        public async Task GetControlVariantNonExistentSplit()
         {
-            var v1 = s1.GetValue(key);
-            var v2 = s2.GetValue(key);
-            if (v1.ToString() != v2.ToString())
+            FlagEvaluationDetails<bool> details = await client.GetBooleanDetailsAsync("non-existent-feature", false);
+            Assert.IsFalse(details.Value);
+            Assert.AreEqual("control", details.Variant);
+            Assert.AreEqual(ErrorType.FlagNotFound, details.ErrorType);
+        }
+
+        [TestMethod]
+        public async Task GetBooleanSplitTest()
+        {
+            var result = await client.GetBooleanValueAsync("some_other_feature", true);
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task GetBooleanSplitWithKeyTest()
+        {
+            var result = await client.GetBooleanValueAsync("my_feature", false);
+            Assert.IsTrue(result);
+
+            var context = EvaluationContext.Builder().Set("targetingKey", "randomKey").Build();
+            result = await client.GetBooleanValueAsync("my_feature", true, context);
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task GetStringSplitTest()
+        {
+            var result = await client.GetStringValueAsync("some_other_feature", "on");
+            Assert.AreEqual("off", result);
+        }
+
+        [TestMethod]
+        public async Task GetIntegerSplitTest()
+        {
+            var result = await client.GetIntegerValueAsync("int_feature", 0);
+            Assert.AreEqual(32, result);
+        }
+
+        [TestMethod]
+        public async Task GetObjectSplitTest()
+        {
+            var result = await client.GetObjectValueAsync("obj_feature", new Value());
+            Structure expectedValue = Structure.Builder().Set("key", new Value("value")).Build();
+            Assert.IsTrue(StructuresMatch(expectedValue, result.AsStructure));
+        }
+
+        [TestMethod]
+        public async Task GetDoubleSplitTest()
+        {
+            var result = await client.GetDoubleValueAsync("int_feature", 0D);
+            Assert.AreEqual(32D, result);
+        }
+
+        [TestMethod]
+        public async Task GetBooleanDetailsTest()
+        {
+            var details = await client.GetBooleanDetailsAsync("some_other_feature", true);
+            Assert.AreEqual("some_other_feature", details.FlagKey);
+            Assert.AreEqual(Reason.TargetingMatch, details.Reason);
+            Assert.IsFalse(details.Value);
+            // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
+            Assert.AreEqual("off", details.Variant);
+            Assert.AreEqual(ErrorType.None, details.ErrorType);
+        }
+
+        [TestMethod]
+        public async Task GetIntegerDetailsAsyncTest()
+        {
+            var details = await client.GetIntegerDetailsAsync("int_feature", 0);
+            Assert.AreEqual("int_feature", details.FlagKey);
+            Assert.AreEqual(Reason.TargetingMatch, details.Reason);
+            Assert.AreEqual(32, details.Value);
+            // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
+            Assert.AreEqual("32", details.Variant);
+            Assert.AreEqual(ErrorType.None, details.ErrorType);
+        }
+
+        [TestMethod]
+        public async Task GetStringDetailsAsyncTest()
+        {
+            var details = await client.GetStringDetailsAsync("some_other_feature", "blah");
+            Assert.AreEqual("some_other_feature", details.FlagKey);
+            Assert.AreEqual(Reason.TargetingMatch, details.Reason);
+            Assert.AreEqual("off", details.Value);
+            // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
+            Assert.AreEqual("off", details.Variant);
+            Assert.AreEqual(ErrorType.None, details.ErrorType);
+        }
+
+        [TestMethod]
+        public async Task GetDoubleDetailsAsyncTest()
+        {
+            var details = await client.GetDoubleDetailsAsync("int_feature", 0D);
+            Assert.AreEqual("int_feature", details.FlagKey);
+            Assert.AreEqual(Reason.TargetingMatch, details.Reason);
+            Assert.AreEqual(32D, details.Value);
+            // the flag has a treatment of "off", this is returned as a value of false but the variant is still "off"
+            Assert.AreEqual("32", details.Variant);
+            Assert.AreEqual(ErrorType.None, details.ErrorType);
+        }
+
+        [TestMethod]
+        public async Task GetObjectDetailsAsyncTest()
+        {
+            var details = await client.GetObjectDetailsAsync("obj_feature", new Value());
+            Assert.AreEqual("obj_feature", details.FlagKey);
+            Assert.AreEqual(Reason.TargetingMatch, details.Reason);
+            Structure expected = Structure.Builder().Set("key", new Value("value")).Build();
+            Assert.IsTrue(StructuresMatch(expected, details.Value.AsStructure));
+            // the flag's treatment is stored as a string, and the variant is that raw string
+            Assert.AreEqual("{\"key\": \"value\"}", details.Variant);
+            Assert.AreEqual(ErrorType.None, details.ErrorType);
+        }
+
+        [TestMethod]
+        public async Task GetBooleanFailTest()
+        {
+            // attempt to fetch an object treatment as a Boolean. Should result in the default
+            var value = await client.GetBooleanValueAsync("obj_feature", false);
+            Assert.IsFalse(value);
+
+            var details = await client.GetBooleanDetailsAsync("obj_feature", false);
+            Assert.IsFalse(details.Value);
+            Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
+            Assert.AreEqual(Reason.Error, details.Reason);
+        }
+
+        [TestMethod]
+        public async Task GetIntegerFailTest()
+        {
+            // attempt to fetch an object treatment as an integer. Should result in the default
+            var value = await client.GetIntegerValueAsync("obj_feature", 10);
+            Assert.AreEqual(10, value);
+
+            var details = await client.GetIntegerDetailsAsync("obj_feature", 10);
+            Assert.AreEqual(10, details.Value);
+            Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
+            Assert.AreEqual(Reason.Error, details.Reason);
+        }
+
+        [TestMethod]
+        public async Task GetDoubleFailTest()
+        {
+            // attempt to fetch an object treatment as a double. Should result in the default
+            var value = await client.GetDoubleValueAsync("obj_feature", 10D);
+            Assert.AreEqual(10D, value);
+
+            var details = await client.GetDoubleDetailsAsync("obj_feature", 10D);
+            Assert.AreEqual(10D, details.Value);
+            Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
+            Assert.AreEqual(Reason.Error, details.Reason);
+        }
+
+        [TestMethod]
+        public async Task GetObjectFailTest()
+        {
+            // attempt to fetch an int as an object. Should result in the default
+            Structure defaultValue = Structure.Builder().Set("key", new Value("value")).Build();
+            var value = await client.GetObjectValueAsync("int_feature", new Value(defaultValue));
+            Assert.IsTrue(StructuresMatch(defaultValue, value.AsStructure));
+
+            var details = await client.GetObjectDetailsAsync("int_feature", new Value(defaultValue));
+            Assert.IsTrue(StructuresMatch(defaultValue, details.Value.AsStructure));
+            Assert.AreEqual(ErrorType.ParseError, details.ErrorType);
+            Assert.AreEqual(Reason.Error, details.Reason);
+        }
+
+        private static bool StructuresMatch(Structure s1, Structure s2)
+        {
+            if (s1.Count != s2.Count)
             {
                 return false;
             }
+            foreach (string key in s1.Keys)
+            {
+                var v1 = s1.GetValue(key);
+                var v2 = s2.GetValue(key);
+                if (v1.ToString() != v2.ToString())
+                {
+                    return false;
+                }
+            }
+            return true;
         }
-        return true;
     }
 }

--- a/ProviderTests/ProviderTests.csproj
+++ b/ProviderTests/ProviderTests.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/ProviderTests/Usings.cs
+++ b/ProviderTests/Usings.cs
@@ -1,1 +1,0 @@
-﻿global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This Provider is designed to allow the use of OpenFeature with Split, the platform for controlled rollouts, serving features to your users via the Split feature flag to manage your complete customer experience.
 
 ## Compatibility
-This SDK is compatible with .NET 6.0 and higher.
+This SDK is compatible with .NET 8.0, 9.0, .NET Framework 4.6.2+ and .NET Standard 2.0.
 
 ## Getting started
 Below is a simple example that describes the instantiation of the Split Provider. Please see the [OpenFeature Documentation](https://docs.openfeature.dev/docs/reference/concepts/evaluation-api) for details on how to use the OpenFeature SDK.

--- a/SplitOpenFeatureProvider/Provider.cs
+++ b/SplitOpenFeatureProvider/Provider.cs
@@ -1,15 +1,20 @@
+using Newtonsoft.Json.Linq;
 using OpenFeature;
-using OpenFeature.Model;
 using OpenFeature.Constant;
 using OpenFeature.Error;
+using OpenFeature.Model;
 using Splitio.Services.Client.Interfaces;
-using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Splitio.OpenFeature
 {
     public class Provider : FeatureProvider
     {
-        private readonly Metadata _metadata = new("Split Client");
+        private readonly Metadata _metadata = new Metadata("Split Client");
         private readonly ISplitClient _client;
 
         public Provider(ISplitClient client)
@@ -20,7 +25,7 @@ namespace Splitio.OpenFeature
         public override Metadata GetMetadata() => _metadata;
 
         public override Task<ResolutionDetails<bool>> ResolveBooleanValueAsync(string flagKey, bool defaultValue,
-            EvaluationContext? context = null, CancellationToken cancellationToken = default)
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var key = GetTargetingKey(context);
             var originalResult = _client.GetTreatment(key, flagKey, TransformContext(context));
@@ -33,7 +38,7 @@ namespace Splitio.OpenFeature
         }
 
         public override Task<ResolutionDetails<string>> ResolveStringValueAsync(string flagKey, string defaultValue,
-            EvaluationContext? context = null, CancellationToken cancellationToken = default)
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var key = GetTargetingKey(context);
             var evaluationResult = _client.GetTreatment(key, flagKey, TransformContext(context));
@@ -45,7 +50,7 @@ namespace Splitio.OpenFeature
         }
 
         public override Task<ResolutionDetails<int>> ResolveIntegerValueAsync(string flagKey, int defaultValue,
-            EvaluationContext? context = null, CancellationToken cancellationToken = default)
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var key = GetTargetingKey(context);
             var originalResult = _client.GetTreatment(key, flagKey, TransformContext(context));
@@ -60,11 +65,11 @@ namespace Splitio.OpenFeature
             catch (FormatException)
             {
                 throw new FeatureProviderException(ErrorType.ParseError, $"{originalResult} is not an int");
-            };
+            }
         }
 
         public override Task<ResolutionDetails<double>> ResolveDoubleValueAsync(string flagKey, double defaultValue,
-            EvaluationContext? context = null, CancellationToken cancellationToken = default)
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var key = GetTargetingKey(context);
             var originalResult = _client.GetTreatment(key, flagKey, TransformContext(context));
@@ -84,7 +89,7 @@ namespace Splitio.OpenFeature
         }
 
         public override Task<ResolutionDetails<Value>> ResolveStructureValueAsync(string flagKey, Value defaultValue,
-            EvaluationContext? context = null, CancellationToken cancellationToken = default)
+            EvaluationContext context = null, CancellationToken cancellationToken = default)
         {
             var key = GetTargetingKey(context);
             var originalResult = _client.GetTreatmentWithConfig(key, flagKey, TransformContext(context));
@@ -131,12 +136,13 @@ namespace Splitio.OpenFeature
 
         private static bool ParseBoolean(string boolStr)
         {
-            return boolStr.ToLower() switch
-            {
-                "on" or "true" => true,
-                "off" or "false" => false,
-                _ => throw new FeatureProviderException(ErrorType.ParseError, $"{boolStr} is not a boolean"),
-            };
+            var boolStrLower = boolStr.ToLower();
+            if (boolStrLower == "on" || boolStrLower == "true")
+                return true;
+            if (boolStrLower == "off" || boolStrLower == "false")
+                return false;
+
+            throw new FeatureProviderException(ErrorType.ParseError, $"{boolStr} is not a boolean");
         }
     }
 }

--- a/SplitOpenFeatureProvider/SplitOpenFeatureProvider.csproj
+++ b/SplitOpenFeatureProvider/SplitOpenFeatureProvider.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net8.0;net9.0;netstandard2.0;net462</TargetFrameworks>
+	<RootNamespace>Splitio.OpenFeature</RootNamespace>
+	<PackageReadmeFile>../README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SplitOpenFeatureProvider/SplitOpenFeatureProvider.csproj
+++ b/SplitOpenFeatureProvider/SplitOpenFeatureProvider.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;netstandard2.0;net462</TargetFrameworks>
 	<RootNamespace>Splitio.OpenFeature</RootNamespace>
-	<PackageReadmeFile>../README.md</PackageReadmeFile>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,5 +15,8 @@
     <PackageReference Include="OpenFeature" Version="2.6.0" />
     <PackageReference Include="Splitio" Version="7.11.0" />
     <PackageReference Include="Microsoft.TestPlatform" Version="17.4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is an extension to #2 to more closely align it with OpenFeature's supported .NET Versions.

For reference:
 - OpenFeature.csproj -> https://github.com/open-feature/dotnet-sdk/blob/main/src/OpenFeature/OpenFeature.csproj
 - OpenFeature.Tests.csproj -> https://github.com/open-feature/dotnet-sdk/blob/main/test/OpenFeature.Tests/OpenFeature.Tests.csproj

Because the number of supported .NET versions spans multiple C# versions, the syntax in most files needed updating. 

Tests have run and passed:
<img width="372" height="92" alt="image" src="https://github.com/user-attachments/assets/20420dd3-3989-4b2a-aea9-ce3de68a9d0f" />
