### PR TITLE
Sync Doc Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Below is a simple example that describes the instantiation of the Split Provider
 
 ```c#
 using OpenFeature;
-using Splitio.OpenFeature;
+using Splitio.OpenFeature.Provider;
 
 Api api = OpenFeature.Api.Instance;
 api.setProviderAsync(new Provider("YOUR_API_KEY"));
@@ -21,7 +21,7 @@ api.setProviderAsync(new Provider("YOUR_API_KEY"));
 If you are more familiar with Split or want access to other initialization options, you can provide a `Split Client` to the constructor. See the [Split .NET Documentation](https://help.split.io/hc/en-us/articles/360020240172--NET-SDK) for more information.
 ```c#
 using OpenFeature;
-using Splitio.OpenFeature;
+using Splitio.OpenFeature.Provider;
 using Splitio.Services.Client.Classes
 
 Api api = OpenFeature.Api.Instance;


### PR DESCRIPTION
Adds `.Provider` to the end of `Splitio.OpenFeature`, as it appears in the documentation (https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/Harness_Commons/repos/developer-hub/pulls/100376/conversation).