### PR TITLE
New strongly typed provider constructor

### DIFF
--- a/ProviderTests/ProviderOptionsTests.cs
+++ b/ProviderTests/ProviderOptionsTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Splitio.OpenFeature.Provider;
+
+namespace ProviderTests
+{
+    [TestClass]
+    public class ProviderOptionsTests
+    {
+        [TestMethod]
+        public void ProviderOptionsConstructorThrowsWhenSdkKeyIsNull()
+        {
+            // arrange, act + assert
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                new ProviderOptions(
+                    null);
+            });
+        }
+    }
+}

--- a/ProviderTests/ProviderTests.cs
+++ b/ProviderTests/ProviderTests.cs
@@ -45,9 +45,16 @@ namespace ProviderTests
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentException), "Missing SplitClient instance or SDK ApiKey")]
-        public async Task InitializeWithNullTest()
+        public async Task InitializeWithNullDictionaryTest()
         {
-            await Api.Instance.SetProviderAsync(new Provider(null));
+            await Api.Instance.SetProviderAsync(new Provider(null as Dictionary<string, object>));
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Missing SplitClient instance or SDK ApiKey")]
+        public async Task InitializeWithNullProviderOptionsTest()
+        {
+            await Api.Instance.SetProviderAsync(new Provider(null as ProviderOptions));
         }
 
         [TestMethod]
@@ -468,6 +475,42 @@ namespace ProviderTests
             catch (Exception) { }
             Assert.AreEqual(0, splitClient.Invocations.Count);
         }
+        
+        [TestMethod]
+        public async Task ProviderConstructorWithOptionsIncludesConfiguration()
+        {
+            // arrange
+            var configuration = new ConfigurationOptions();
+            var options = new ProviderOptions(
+                "test-sdk-key",
+                configuration,
+                1234);
+
+            // act
+            await Api.Instance.SetProviderAsync(new Provider(options));
+            var featureClient = Api.Instance.GetClient();
+
+            // assert
+            Assert.IsNotNull(featureClient);
+        }
+        
+        [TestMethod]
+        public async Task ProviderConstructorWithOptionsWithoutConfigurationUsesDefaults()
+        {
+            // arrange
+            var options = new ProviderOptions(
+                "test-sdk-key",
+                null,
+                10000);
+
+            // act
+            await Api.Instance.SetProviderAsync(new Provider(options));
+            var featureClient = OpenFeature.Api.Instance.GetClient();
+
+            // assert
+            Assert.IsNotNull(featureClient);
+        }
+
 
         private static bool StructuresMatch(Structure s1, Structure s2)
         {

--- a/Splitio.OpenFeature.Provider/Constants.cs
+++ b/Splitio.OpenFeature.Provider/Constants.cs
@@ -9,6 +9,6 @@
         public const string ConfigKey = "ConfigOptions";
         public const string TrafficType = "trafficType";
         public const string ReadyBlockTime = "ReadyBlockTime";
-
+        public const int DefaultReadyBlockTime = 10000;
     }
 }

--- a/Splitio.OpenFeature.Provider/Provider.cs
+++ b/Splitio.OpenFeature.Provider/Provider.cs
@@ -37,6 +37,11 @@ namespace Splitio.OpenFeature.Provider
             _splitWrapper = CreateSplitWrapper(initialContext);
             _log = WrapperAdapter.Instance().GetLogger(typeof(Provider));
         }
+        
+        public Provider(ProviderOptions options)
+            : this(ToInitialContext(options))
+        {
+        }
 
         public override Metadata GetMetadata() => _metadata;
 
@@ -314,6 +319,24 @@ namespace Splitio.OpenFeature.Provider
             }
 
             return true;
+        }
+        
+        private static Dictionary<string, object> ToInitialContext(ProviderOptions options)
+        {
+            var initialContext = new Dictionary<string, object>();
+
+            if (options != null)
+            {
+                initialContext[Constants.SdkApiKey] = options.SdkKey;
+                initialContext[Constants.ReadyBlockTime] = options.ReadyBlockTime;
+            }
+
+            if (options?.Configuration != null)
+            {
+                initialContext[Constants.ConfigKey] =  options.Configuration;
+            }
+
+            return initialContext;
         }
     }
 }

--- a/Splitio.OpenFeature.Provider/ProviderOptions.cs
+++ b/Splitio.OpenFeature.Provider/ProviderOptions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Splitio.Services.Client.Classes;
+
+namespace Splitio.OpenFeature.Provider
+{
+    public sealed class ProviderOptions
+    {
+        public string SdkKey { get; }
+        public ConfigurationOptions Configuration { get; }
+        public int ReadyBlockTime { get; }
+
+        public ProviderOptions(
+            string sdkKey,
+            ConfigurationOptions configOptions = null,
+            int readyBlockTime = Constants.DefaultReadyBlockTime)
+        {
+            SdkKey = sdkKey ?? throw new ArgumentNullException(nameof(sdkKey));
+            Configuration = configOptions;
+            ReadyBlockTime = readyBlockTime;
+        }
+    }
+}

--- a/Splitio.OpenFeature.Provider/README.md
+++ b/Splitio.OpenFeature.Provider/README.md
@@ -14,18 +14,18 @@ Below is a simple example that describes the instantiation of the Split Provider
 using OpenFeature;
 using Splitio.OpenFeature;
 
-Dictionary<string, object> initialContext = new Dictionary<string, object>();
-var config = new ConfigurationOptions
-{
-    Logger = new CustomLogger()
-};
-initialContext.Add("ConfigOptions", config);
-initialContext.Add("SdkKey", "SPLIT SDK API KEY");
-initialContext.Add("ReadyBlockTime", 5000);
+var options = new ProviderOptions(
+    sdkKey: "SPLIT SDK API KEY",
+    configuration: new ConfigurationOptions
+    {
+        Logger = new CustomLogger()
+    },
+    readyBlockTime: 5000
+);
 
 Api api = OpenFeature.Api.Instance;
 
-api.setProviderAsync(new Provider(initialContext));
+api.setProviderAsync(new Provider(options));
 ```
 
 If you are more familiar with Split or want access to other initialization options, you can provide a `Split Client` to the constructor. See the [Split .NET Documentation](https://help.split.io/hc/en-us/articles/360020240172--NET-SDK) for more information.

--- a/Splitio.OpenFeature.Provider/SplitWrapper.cs
+++ b/Splitio.OpenFeature.Provider/SplitWrapper.cs
@@ -16,7 +16,7 @@ namespace Splitio.OpenFeature.Provider
             this.splitClient = splitClient;
         }
 
-        public SplitWrapper(string SdkKey, ConfigurationOptions Configs, int ReadyBlockTime=10000) 
+        public SplitWrapper(string SdkKey, ConfigurationOptions Configs, int ReadyBlockTime=Constants.DefaultReadyBlockTime) 
         {
             var factory = new SplitFactory(SdkKey, Configs);
             _log = WrapperAdapter.Instance().GetLogger(typeof(SplitWrapper));


### PR DESCRIPTION
This change adds in a clearer option for constructing a Provider that offers better visibility into initializing the SDK while mostly just facading for the original implementation.